### PR TITLE
replaced deprecated luaL_register

### DIFF
--- a/lmcchlib.c
+++ b/lmcchlib.c
@@ -320,7 +320,10 @@ LUALIB_API int luaopen_bd_mcch(lua_State *L)
 	//metatable for main table
 	lua_createtable(L, 0, 2);
 
-	luaL_register(L, LUA_MCCHLIBNAME, mcch_funcs);
+	luaL_setfuncs(L, mcch_funcs, 0);
+	lua_pushvalue(L, -1);
+	lua_setglobal(L, LUA_MCCHLIBNAME);
+
 	lua_setfield(L, -2, "__index");
 	lua_pushcfunction(L, setreadonly);
 	lua_setfield(L, -2, "__newindex");


### PR DESCRIPTION
Under Lua 5.2.3_2 I had to replace luaL_register to get the library to compile.
